### PR TITLE
Alpine Linux support

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[target.x86_64-unknown-linux-musl]
+rustflags = ["-C", "link-arg=-lc"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = "3.0.0-beta.2"
+clap = "3.2.6"
 paho-mqtt = "0.9.1"
 tokio = { version = "1.2.0", features = ["full"] }
 tokio-stream = "0.1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,6 @@ edition = "2018"
 
 [dependencies]
 clap = "3.2.6"
-paho-mqtt = "0.9.1"
+paho-mqtt = "0.10"
 tokio = { version = "1.2.0", features = ["full"] }
 tokio-stream = "0.1.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,20 +48,20 @@ async fn main() {
                 .short('h')
                 .long("host")
                 .value_name("HOST")
-                .about("Sets the MQTT broker host")
+                .help("Sets the MQTT broker host")
                 .required(true),
         )
         .arg(
             Arg::new("request_topic")
                 .long("request")
-                .about("Sets the topic name to which sends requests")
+                .help("Sets the topic name to which sends requests")
                 .value_name("REQUEST_TOPIC")
                 .required(true),
         )
         .arg(
             Arg::new("response_topic")
                 .long("response")
-                .about("Sets the topic name to which the response is sent")
+                .help("Sets the topic name to which the response is sent")
                 .value_name("RESPONSE_TOPIC")
                 .required(true),
         )
@@ -69,25 +69,25 @@ async fn main() {
             Arg::new("payload")
                 .short('p')
                 .long("payload")
-                .about("The payload for the healthckeck request (default: \"healthcheck\")"),
+                .help("The payload for the healthckeck request (default: \"healthcheck\")"),
         )
         .arg(
             Arg::new("expect")
                 .short('e')
                 .long("expect")
-                .about("The expected payload in the healthckeck response"),
+                .help("The expected payload in the healthckeck response"),
         )
         .arg(
             Arg::new("interval")
                 .short('i')
                 .long("interval")
-                .about("The interval period for sending a request (default: 2 seconds)"),
+                .help("The interval period for sending a request (default: 2 seconds)"),
         )
         .arg(
             Arg::new("timeout")
                 .short('t')
                 .long("timeout")
-                .about("The timeout (seconds) to exit with an error status (default: 16 seconds)"),
+                .help("The timeout (seconds) to exit with an error status (default: 16 seconds)"),
         )
         .get_matches()
         .into();


### PR DESCRIPTION
This patch series will adds support for building a binary with MUSL libc. (Which is required for Alpine Linux environment.)

Verified with https://github.com/emk/rust-musl-builder

```
$ cd mqtt-healthchecker-rs
$ alias rust-musl-builder='docker run --rm -it -v "$(pwd)":/home/rust/src ekidd/rust-musl-builder'
$ rust-musl-builder cargo build --release
$ ls target/x86_64-unknown-linux-musl/release/
build/  deps/  examples/  incremental/  mqtt-healthchecker-rs*  mqtt-healthchecker-rs.d
```